### PR TITLE
Minor changes to make it compile under 3.19

### DIFF
--- a/core/rtw_debug.c
+++ b/core/rtw_debug.c
@@ -63,7 +63,7 @@ u32 GlobalDebugLevel = _drv_err_;
 void dump_drv_version(void *sel)
 {
 	DBG_871X_SEL_NL(sel, "%s %s\n", DRV_NAME, DRIVERVERSION);
-	DBG_871X_SEL_NL(sel, "build time: %s %s\n", __DATE__, __TIME__);
+//	DBG_871X_SEL_NL(sel, "build time: %s %s\n", __DATE__, __TIME__);
 }
 
 void dump_log_level(void *sel)

--- a/os_dep/rtw_android.c
+++ b/os_dep/rtw_android.c
@@ -342,7 +342,7 @@ int rtw_android_cmdstr_to_num(char *cmdstr)
 {
 	int cmd_num;
 	for(cmd_num=0 ; cmd_num<ANDROID_WIFI_CMD_MAX; cmd_num++)
-		if(0 == strnicmp(cmdstr , android_wifi_cmd_str[cmd_num], strlen(android_wifi_cmd_str[cmd_num])) )
+		if(0 == strncasecmp(cmdstr , android_wifi_cmd_str[cmd_num], strlen(android_wifi_cmd_str[cmd_num])) )
 			break;
 
 	return cmd_num;


### PR DESCRIPTION
Just a couple of changes to make it compile under kernel 3.19. It still produces the following warnings, but I can't figure out why because the function signatures appear to be correct:

````
/home/developer/drivers/rtl8723bu/os_dep/ioctl_cfg80211.c:6060:2: warning: initialization from incompatible pointer type
  .scan = cfg80211_rtw_scan,
  ^
/home/developer/drivers/rtl8723bu/os_dep/ioctl_cfg80211.c:6060:2: warning: (near initialization for ‘rtw_cfg80211_ops.get_station’)
/home/developer/drivers/rtl8723bu/os_dep/ioctl_cfg80211.c:6089:2: warning: initialization from incompatible pointer type
  .change_station = cfg80211_rtw_change_station,
  ^
/home/developer/drivers/rtl8723bu/os_dep/ioctl_cfg80211.c:6089:2: warning: (near initialization for ‘rtw_cfg80211_ops.del_station’)
/home/developer/drivers/rtl8723bu/os_dep/ioctl_cfg80211.c:6091:2: warning: initialization from incompatible pointer type
  .change_bss = cfg80211_rtw_change_bss,
  ^
/home/developer/drivers/rtl8723bu/os_dep/ioctl_cfg80211.c:6091:2: warning: (near initialization for ‘rtw_cfg80211_ops.dump_station’)
````

