### PR TITLE
Added CONFIG_PLATFORM_ARM, defaults to CONFIG_PLATFORM_I386_PC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ CONFIG_PNO_SUPPORT = n
 CONFIG_PNO_SET_DEBUG = n
 CONFIG_AP_WOWLAN = n
 ###################### Platform Related #######################
-CONFIG_PLATFORM_I386_PC = y
+CONFIG_PLATFORM_I386_PC = n
+CONFIG_RASPBIAN = y
 ###############################################################
 
 CONFIG_DRVEXT_MODULE = n
@@ -248,6 +249,18 @@ ifeq ($(CONFIG_GPIO_WAKEUP), y)
 EXTRA_CFLAGS += -DCONFIG_GPIO_WAKEUP
 endif
 
+ifeq ($(CONFIG_RASPBIAN), y)
+EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211
+EXTRA_CFLAGS += -DRTW_USE_CFG80211_STA_EVENT # only enable when kernel >= 3.2
+EXTRA_CFLAGS += -DCONFIG_P2P_IPS
+ARCH := arm
+CROSS_COMPILE := arm-linux-gnueabihf-
+KVER := $(shell uname -r)
+KSRC ?= /lib/modules/$(KVER)/build
+MODULE_NAME := 8723bu
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+endif
 
 ifeq ($(CONFIG_PLATFORM_I386_PC), y)
 EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211

--- a/Makefile
+++ b/Makefile
@@ -344,8 +344,6 @@ else
 
 export CONFIG_RTL8723BU = m
 
-error:
-	@echo "No PLATFORM was set in Makefile"
 
 all: modules
 

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,9 @@ CONFIG_PNO_SUPPORT = n
 CONFIG_PNO_SET_DEBUG = n
 CONFIG_AP_WOWLAN = n
 ###################### Platform Related #######################
-CONFIG_PLATFORM_I386_PC = n
-CONFIG_RASPBIAN = n
+CONFIG_PLATFORM_I386_PC ?= y
+CONFIG_PLATFORM_ARM ?= n
+CONFIG_RASPBIAN ?= n
 ###############################################################
 
 CONFIG_DRVEXT_MODULE = n

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ CONFIG_PNO_SET_DEBUG = n
 CONFIG_AP_WOWLAN = n
 ###################### Platform Related #######################
 CONFIG_PLATFORM_I386_PC = n
-CONFIG_RASPBIAN = y
+CONFIG_RASPBIAN = n
 ###############################################################
 
 CONFIG_DRVEXT_MODULE = n
@@ -249,6 +249,21 @@ ifeq ($(CONFIG_GPIO_WAKEUP), y)
 EXTRA_CFLAGS += -DCONFIG_GPIO_WAKEUP
 endif
 
+ifeq ($(CONFIG_PLATFORM_ARM), y)
+EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211
+EXTRA_CFLAGS += -DRTW_USE_CFG80211_STA_EVENT # only enable when kernel >= 3.2
+EXTRA_CFLAGS += -DCONFIG_P2P_IPS
+ARCH := arm
+CROSS_COMPILE := arm-linux-gnueabihf-
+KVER := $(KERNEL_VERSION)
+KSRC := $(KERNEL_PATH)	
+#KERNEL_SOURCE ?= /lib/modules/$(KVER)/build
+MODULE_NAME := 8723bu
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+endif
+
+
 ifeq ($(CONFIG_RASPBIAN), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211
@@ -327,6 +342,9 @@ obj-$(CONFIG_RTL8723BU) := $(MODULE_NAME).o
 else
 
 export CONFIG_RTL8723BU = m
+
+error:
+	@echo "No PLATFORM was set in Makefile"
 
 all: modules
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-# rtl8723bu
+rtl8723bu
+=========
+
 Driver for Realtek RTL8723BU Wireless Adapter with Hardware ID `0bda:b720`
+
+Supports building of module for the Raspberry Pi 1/2/3 or Zero 
+under Yocto
+
 
 # How to use?
 ## a. Concurrent Mode


### PR DESCRIPTION
Added the CONFIG_PLATFORM_ARM to initialise KSRC with value of KERNEL_PATH.
This is given by Yocto environment, which makes driver able to build without modifications.

Due to merge from Diagonatic I left the CONFIG_RASPBIAN in parallel.

By default it compiles for i386, due to ?= initialization.

 