### PR TITLE
Modify makefile to handle empty INSTALL_MOD_PATH. Fixes #79

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,11 @@ strip:
 
 install:
 	install -p -m 644 -D $(MODULE_NAME).ko $(MODDESTDIR)$(MODULE_NAME).ko
+ifeq ($(INSTALL_MOD_PATH),)
+	$(DEPMOD) -a ${KVER}
+else
 	$(DEPMOD) -b "$(INSTALL_MOD_PATH)" -a ${KVER}
+endif
 	install rtl8723b_fw.bin -D $(FW_DIR)/rtl8723b_fw.bin
 
 uninstall:


### PR DESCRIPTION
Depmod has a "-b" flag to set a different base dir from the usual /lib/modules.
A recent patch (365b0e134631bbc70bef075464f042a3638bbb06) introduced a way to use this in the Makefile.
However it seems like depmod handles an empty string as the argument for the flag by using the current directory as the base dir instead of reverting to the default path. See issue #79.
This patch handles both possibilties in the makefile by checking if INSTALL_MOD_PATH is empty.