### PR TITLE
rtl8723bu: Fix connection error on resume

### DIFF
--- a/os_dep/ioctl_cfg80211.c
+++ b/os_dep/ioctl_cfg80211.c
@@ -839,6 +839,9 @@ void rtw_cfg80211_indicate_disconnect(_adapter *padapter)
 #else
 			cfg80211_disconnected(padapter->pnetdev, 0, NULL, 0, GFP_ATOMIC);
 #endif
+		else
+			cfg80211_connect_result(padapter->pnetdev, NULL, NULL, 0, NULL, 0,
+						WLAN_STATUS_UNSPECIFIED_FAILURE, GFP_ATOMIC);
 #endif // kernel >= 3.11
 	}
 }


### PR DESCRIPTION
The problem (as read in [0]) is that commit 51e13359 ("cfg80211: fix
connect/disconnect edge cases") upstream is causing a regression in the
rtl8723bu downstream driver that is now refusing to reconnect to the AP
after resuming from suspend.

The underlying issue is that when disconnecting without bringing the
link down (like when going into suspend mode) the driver will proceed to
disconnect but cfg80211_disconnected() will not be called.

To fix this problem we align the current downstream driver to what is
done by other rtl drivers and notably upstream by the rtl8723bs driver
in the staging directory, emitting a
cfg80211_connect_result(..,WLAN_STATUS_UNSPECIFIED_FAILURE,..) in the
problematic case. This is probably not 100% correct (since we would
expect a cfg80211_disconnected() to be emitted) but it works fine and it
is consistent among all the drivers.

[0] https://github.com/lwfinger/rtl8723bu/issues/91

Signed-off-by: Carlo Caione <carlo@endlessm.com>