### PR TITLE
Fix connection on resume when CONFIG_ANDROID=y

### DIFF
--- a/os_dep/os_intfs.c
+++ b/os_dep/os_intfs.c
@@ -2458,7 +2458,6 @@ static int netdev_close(struct net_device *pnetdev)
 				rtw_netif_stop_queue(pnetdev);
 		}
 
-#ifndef CONFIG_ANDROID
 		//s2.
 		LeaveAllPowerSaveMode(padapter);
 		rtw_disassoc_cmd(padapter, 500, _FALSE);
@@ -2468,7 +2467,6 @@ static int netdev_close(struct net_device *pnetdev)
 		rtw_free_assoc_resources(padapter, 1);
 		//s2-4.
 		rtw_free_network_queue(padapter,_TRUE);
-#endif
 		// Close LED
 		rtw_led_control(padapter, LED_CTL_POWER_OFF);
 	}


### PR DESCRIPTION
The partial fix made in commit 2913f99da92a96364b2 relies on the
fact that during suspend/resume, netdev_close() calls
rtw_indicate_disconnect() and that ultimately informs cfg80211 that
we have disconnected.

However that codepath doesn't run when CONFIG_ANDROID=y, so this bug
is effectively back on kernels where that option is set, including
current Ubuntu kernels.

It's not a complete fix but should keep this codebase hobbling along...

Going forward, the newer v5 driver mentioned in
https://github.com/lwfinger/rtl8723bu/issues/144
looks like it should handle this situation much better, as long as
RTW_CFG80211_ALWAYS_INFORM_STA_DISCONNECT_EVENT is set, which
I'd recommend doing.

Signed-off-by: Daniel Drake <drake@endlessm.com>