### PR TITLE
rtl8723bu: fix wireless regulatory API misuse

### DIFF
--- a/include/rtw_wifi_regd.h
+++ b/include/rtw_wifi_regd.h
@@ -26,7 +26,7 @@ enum country_code_type_t {
 	COUNTRY_CODE_MAX
 };
 
-int rtw_regd_init(_adapter *padapter,
+void rtw_regd_init(struct wiphy *wiphy,
 	void (*reg_notifier)(struct wiphy *wiphy,
 		struct regulatory_request *request));
 void rtw_reg_notifier(struct wiphy *wiphy, struct regulatory_request *request);

--- a/os_dep/ioctl_cfg80211.c
+++ b/os_dep/ioctl_cfg80211.c
@@ -5762,9 +5762,6 @@ void rtw_cfg80211_init_wiphy(_adapter *padapter)
 			rtw_cfg80211_init_ht_capab(&bands->ht_cap, IEEE80211_BAND_5GHZ, rf_type);
 	}
 
-	/* init regulary domain */
-	rtw_regd_init(padapter, rtw_reg_notifier);
-
 	/* copy mac_addr to wiphy */
 	_rtw_memcpy(wiphy->perm_addr, padapter->eeprompriv.mac_addr, ETH_ALEN);
 
@@ -5976,6 +5973,9 @@ int rtw_wdev_alloc(_adapter *padapter, struct device *dev)
 	set_wiphy_dev(wiphy, dev);
 	*((_adapter**)wiphy_priv(wiphy)) = padapter;
 	rtw_cfg80211_preinit_wiphy(padapter, wiphy);
+
+	/* init regulary domain */
+	rtw_regd_init(wiphy, rtw_reg_notifier);
 
 	ret = wiphy_register(wiphy);
 	if (ret < 0) {

--- a/os_dep/wifi_regd.c
+++ b/os_dep/wifi_regd.c
@@ -379,16 +379,11 @@ static struct country_code_to_enum_rd *_rtw_regd_find_country(u16 countrycode)
 	return NULL;
 }
 
-int rtw_regd_init(_adapter * padapter,
+void rtw_regd_init(struct wiphy *wiphy,
 		  void (*reg_notifier) (struct wiphy * wiphy,
 				       struct regulatory_request * request))
 {
-	//struct registry_priv  *registrypriv = &padapter->registrypriv;
-	struct wiphy *wiphy = padapter->rtw_wdev->wiphy;
-
 	_rtw_regd_init_wiphy(NULL, wiphy, reg_notifier);
-
-	return 0;
 }
 
 void rtw_reg_notifier(struct wiphy *wiphy, struct regulatory_request *request)


### PR DESCRIPTION
This is 81f153faacd0 ("staging: rtl8723bs: fix wireless regulatory API
misuse") in Linus' tree.  Original commit message follows.

This code ends up calling wiphy_apply_custom_regulatory(), for which
we document that it should be called before wiphy_register(). This
driver doesn't do that, but calls it from ndo_open() with the RTNL
held, which caused deadlocks.

Since the driver just registers static regdomain data and then the
notifier applies the channel changes if any, there's no reason for
it to call this in ndo_open(), move it earlier to fix the deadlock.

Signed-off-by: Johannes Berg <johannes.berg@intel.com>
Signed-off-by: Mans Rullgard <mans@mansr.com>