### PR TITLE
rtl8723bu: move wiphy setup to after reading the regulatory settings

### DIFF
--- a/os_dep/usb_intf.c
+++ b/os_dep/usb_intf.c
@@ -997,12 +997,6 @@ static _adapter *rtw_usb_if1_init(struct dvobj_priv *dvobj,
 	SET_NETDEV_DEV(pnetdev, dvobj_to_dev(dvobj));
 	padapter = rtw_netdev_priv(pnetdev);
 
-#ifdef CONFIG_IOCTL_CFG80211
-	if(rtw_wdev_alloc(padapter, dvobj_to_dev(dvobj)) != 0) {
-		goto handle_dualmac;
-	}
-#endif
-
 	//step 2. hook HalFunc, allocate HalData
 	//hal_set_hal_ops(padapter);
 	rtw_set_hal_ops(padapter);
@@ -1079,6 +1073,12 @@ static _adapter *rtw_usb_if1_init(struct dvobj_priv *dvobj,
 	#endif
 #ifdef	CONFIG_BT_COEXIST
 	dvobj_to_pwrctl(dvobj)->autopm_cnt=1;
+#endif
+
+#ifdef CONFIG_IOCTL_CFG80211
+	if(rtw_wdev_alloc(padapter, dvobj_to_dev(dvobj)) != 0) {
+		goto free_hal_data;
+	}
 #endif
 
 	// set mac addr


### PR DESCRIPTION
This corresponds to 50af06d43eab ("staging: rtl8723bs: Move wiphy setup
to after reading the regulatory settings from the chip") in Linus' tree.

Commit d6ed42081580 ("rtl8723bu: fix wireless regulatory API misuse")
moved the wiphy_apply_custom_regulatory() call to earlier in the
driver's init-sequence, so that it gets called before wiphy_register().

But at this point in time the eFuses which code the regulatory-settings
for the chip have not been read by the driver yet, causing
_rtw_reg_apply_flags() to set the IEEE80211_CHAN_DISABLED flag on *all*
channels.

We cannot move the wiphy_apply_custom_regulatory() call back, because
that call must be made before the wiphy_register() call.

Instead move the entire rtw_wdev_alloc() call to after the Efuses have
been read, fixing all channels being disabled in the initial channel-map.

Fixes: d6ed42081580 ("rtl8723bu: fix wireless regulatory API misuse")
Signed-off-by: Hans de Goede <hdegoede@redhat.com>
Signed-off-by: Mans Rullgard <mans@mansr.com>