### PR TITLE
rtl8723bu: Add TRENDnet TBW-108UB to USB device list

### DIFF
--- a/os_dep/usb_intf.c
+++ b/os_dep/usb_intf.c
@@ -131,6 +131,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	//*=== Realtek demoboard ===*/
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xB720,0xff,0xff,0xff),.driver_info = RTL8723B}, /* 8723BU 1*1 */
 	{USB_DEVICE_AND_INTERFACE_INFO(0x7392, 0xa611, 0xff, 0xff, 0xff), .driver_info = RTL8723B}, /* 8723BU 1*1 */
+	{USB_DEVICE_AND_INTERFACE_INFO(0x20f4, 0x108a, 0xff, 0xff, 0xff), .driver_info = RTL8723B}, /* 8723BU 1*1 */
 	{}	/* Terminating entry */
 };
 


### PR DESCRIPTION
The Wi-Fi device does work with this patch, although strangely two Wi-Fi interfaces appear and only the first one is functional.

Based on https://github.com/jeremyb31/rtl8723bu/commit/20f0f24ee2b84e811610d53e13399bd86171d878

See https://askubuntu.com/a/1149435/223160

Signed-off-by: Alex Henrie <alexh@vpitech.com>