### PR TITLE
Indicate disconnection events when disconnecting

### DIFF
--- a/os_dep/ioctl_cfg80211.c
+++ b/os_dep/ioctl_cfg80211.c
@@ -2822,8 +2822,6 @@ static int cfg80211_rtw_leave_ibss(struct wiphy *wiphy, struct net_device *ndev)
 
 	DBG_871X(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(ndev));
 
-	padapter->mlmepriv.not_indic_disco = _TRUE;
-
 	old_type = rtw_wdev->iftype;
 
 	rtw_set_to_roam(padapter, 0);
@@ -2845,8 +2843,6 @@ static int cfg80211_rtw_leave_ibss(struct wiphy *wiphy, struct net_device *ndev)
 	}
 
 leave_ibss:
-	padapter->mlmepriv.not_indic_disco = _FALSE;
-
 	return 0;
 }
 
@@ -3111,8 +3107,6 @@ static int cfg80211_rtw_disconnect(struct wiphy *wiphy, struct net_device *ndev,
 
 	DBG_871X(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(ndev));
 
-	padapter->mlmepriv.not_indic_disco = _TRUE;
-
 	rtw_set_to_roam(padapter, 0);
 
 	//if(check_fwstate(&padapter->mlmepriv, _FW_LINKED))
@@ -3128,8 +3122,6 @@ static int cfg80211_rtw_disconnect(struct wiphy *wiphy, struct net_device *ndev,
 		rtw_free_assoc_resources(padapter, 1);
 		rtw_pwr_wakeup(padapter);
 	}
-
-	padapter->mlmepriv.not_indic_disco = _FALSE;
 
 	DBG_871X(FUNC_NDEV_FMT" return 0\n", FUNC_NDEV_ARG(ndev));
 	return 0;


### PR DESCRIPTION
I did not author this commit, but I found it in another repository (https://github.com/endlessm/linux/commit/eb1bdcedc448a03ffe899b54eb455d253acc6b2b). This fixes an issue that prevents you from changing between access points.

In the current version of this driver, I am unable to change which AP I connect to. Once I've connected to an AP, I'm stuck with that AP. If I try to connect to a different AP, everything gets messed up and it never successfully connects ever again, until I remove the kernel module and reinsert it (or reboot). It just prints this over and over again while trying to connect:

```
RTL871X: nolinked power save enter
RTL871X: RTW_ADAPTIVITY_EN_
AUTO, chplan:0x20, Regulation:0,0
RTL871X: RTW_ADAPTIVITY_MODE_
NORMAL
RTL871X: nolinked power save leave
```

As you can see in the commit message by the original author, it seems as though there's some weird unnecessary event suppression going on in this driver that Realtek removed in newer drivers for other hardware. This commit definitely fixes the issue for me. After applying this patch, I am able to connect to any number of APs with no trouble.