### PR TITLE
fix build for 5.19.2

### DIFF
--- a/os_dep/ioctl_cfg80211.c
+++ b/os_dep/ioctl_cfg80211.c
@@ -3969,7 +3969,12 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
 	return ret;
 }
 
+#if (LINUX_VERSION_CODE <= KERNEL_VERSION(5, 19, 1))
 static int cfg80211_rtw_stop_ap(struct wiphy *wiphy, struct net_device *ndev)
+#else
+static int cfg80211_rtw_stop_ap(struct wiphy *wiphy, struct net_device *ndev,
+                                unsigned int link_id)
+#endif
 {
 	DBG_871X(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(ndev));
 	return 0;


### PR DESCRIPTION
`/var/lib/dkms/rtl8723bu/260/build/os_dep/ioctl_cfg80211.c:5905:20: error: initialization of «int (*)(struct wiphy *, struct net_device *, unsigned int)» from incompatible pointer type «int (*)(struct wiphy *, struct net_device *)» [-Werror=incompatible-pointer-types]`