### PR TITLE
Fix build failure on PowerPc architecture

### DIFF
--- a/hal/rtl8723bu_recv.c
+++ b/hal/rtl8723bu_recv.c
@@ -288,7 +288,7 @@ void update_recvframe_phyinfo(
 		!pattrib->icv_err && !pattrib->crc_err &&
 		_rtw_memcmp(get_hdr_bssid(wlanhdr), get_bssid(&padapter->mlmepriv), ETH_ALEN));
 
-	pkt_info.bPacketToSelf = pkt_info.bPacketMatchBSSID && (_rtw_memcmp(get_ra(wlanhdr), myid(&padapter->eeprompriv), ETH_ALEN));
+	pkt_info.bPacketToSelf = pkt_info.bPacketMatchBSSID && (_rtw_memcmp(wifi_get_ra(wlanhdr), myid(&padapter->eeprompriv), ETH_ALEN));
 
 	pkt_info.bPacketBeacon = pkt_info.bPacketMatchBSSID && (GetFrameSubType(wlanhdr) == WIFI_BEACON);
 	sa = get_ta(wlanhdr);

--- a/include/wifi.h
+++ b/include/wifi.h
@@ -373,7 +373,7 @@ __inline static int IS_MCAST(unsigned char *da)
 		return _FALSE;
 }
 
-__inline static unsigned char * get_ra(unsigned char *pframe)
+__inline static unsigned char * wifi_get_ra(unsigned char *pframe)
 {
 	unsigned char	*ra;
 	ra = GetAddr1Ptr(pframe);


### PR DESCRIPTION
In PowerPc Linux only get_ra() exists[0] and conflicts with local get_ra() that has a completely different purpose. So let's rename local get_ra() to wifi_get_ra() to make it different from Linux's get_ra().

[0]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/powerpc/include/asm/disassemble.h#n49

Signed-off-by: Giulio Benetti <giulio.benetti@benettiengineering.com>