### PR TITLE
os_dep/ioctl_cfg80211.c: fix build failure with Linux version < 2.6.38

### DIFF
--- a/os_dep/ioctl_cfg80211.c
+++ b/os_dep/ioctl_cfg80211.c
@@ -1611,9 +1611,9 @@ static int cfg80211_rtw_set_default_key(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)) || defined(COMPAT_KERNEL_RELEASE)
 					int link_id,
 #endif
-					u8 key_index,
+					u8 key_index
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,38)) || defined(COMPAT_KERNEL_RELEASE)
-					bool unicast, bool multicast
+					, bool unicast, bool multicast
 #endif
 	)
 {


### PR DESCRIPTION
While fixing for Linux 6.1 commit 5b7ddfe0eab3a29847a8eb5e9563ef6059d744a5 introduced a bug that appears while building for Linux version 2.6.38. It is very unlikely that someone will use this driver with so old version, but let's fix it anyway.

Signed-off-by: Giulio Benetti <giulio.benetti@benettiengineering.com>