### PR TITLE
rtl8723bu: Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 INSTALL_FW_PATH = $(INSTALL_MOD_PATH)/lib/firmware
 FW_DIR	:= $(INSTALL_FW_PATH)/rtl_bt
+MODDESTDIR := kernel/drivers/net/wireless/
 
 DEPMOD  = /sbin/depmod
 
@@ -262,7 +263,6 @@ ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=
 KVER  := $(shell uname -r)
 KSRC := /lib/modules/$(KVER)/build
-MODDESTDIR := $(INSTALL_MOD_PATH)/lib/modules/$(KVER)/kernel/drivers/net/wireless/
 INSTALL_PREFIX :=
 endif
 
@@ -273,7 +273,6 @@ EXTRA_CFLAGS += -DCONFIG_P2P_IPS
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -Wno-error=date-time
 ARCH := arm
 KSRC ?= $(KERNEL_SRC)
-MODDESTDIR := kernel/drivers/net/wireless/
 LICENSE = "GPLv2"
 endif
 


### PR DESCRIPTION
According to the manual
(https://docs.kernel.org/kbuild/modules.html?highlight=kernel_src#install-mod-path) INSTALL_MOD_PATH is supposed to set relative prefix, which is misused for cross-compilation

@honteng The FS_MX61 platfrom you introduced earlier looks very similar to my use-case. I compile the module using Yocto project. If that's the case, perhaps we could simplify Makefile and drop a few conditions.
@DerDakon Please take a look that it doesn't break your use-case